### PR TITLE
Fix crash when creating or updating contents.

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -144,7 +144,7 @@ module RubWiki2
     end
 
     def self.create_tree_object(repo, children)
-      builder = Rugged::Tree::Builder.new()
+      builder = Rugged::Tree::Builder.new(repo)
       children.each do |name, obj|
         case obj.type
         when :blob
@@ -153,7 +153,7 @@ module RubWiki2
           builder.insert({ type: obj.type, name: name, oid: obj.oid, filemode: 0040000 })
         end
       end
-      oid = builder.write(repo)
+      oid = builder.write
       Git.chmod(repo, oid)
       return oid
     end


### PR DESCRIPTION
Rugged::Tree::Builder.new requires repository instance

> The Rugged::Tree::Builder API was changed to account for libgit2 changes.
> 
> When creating a new Rugged::Tree::Builder instance through Rugged::Tree::Builder.new you have to pass a repository instance, while Rugged::Tree::Builder#write does not take any arguments anymore.

https://github.com/libgit2/rugged/blob/585f09404d525e95cba38869c24c37dbfe72f477/CHANGELOG.md