### PR TITLE
表示あふれ時にスクロールバーを出す

### DIFF
--- a/views/style.scss
+++ b/views/style.scss
@@ -367,6 +367,7 @@ div#content-html {
         @include border;
         padding: 10px;
         background-color: ghostwhite;
+        overflow: auto;
     }
 
     table {

--- a/views/style.scss
+++ b/views/style.scss
@@ -137,10 +137,6 @@ $padding: 7px;
     div#content {
         margin: 0;
         padding: $padding;
-
-        ul {
-            overflow: auto;
-        }
     }
 
     div#tab {
@@ -326,6 +322,7 @@ div#content-html {
     border-color: white;
     margin: 0;
     padding: 0 30px;
+    overflow-wrap: break-word;
 
     line-height: 1.5em;
 

--- a/views/style.scss
+++ b/views/style.scss
@@ -137,6 +137,10 @@ $padding: 7px;
     div#content {
         margin: 0;
         padding: $padding;
+
+        ul {
+            overflow: auto;
+        }
     }
 
     div#tab {


### PR DESCRIPTION
## pre タグの表示あふれ時にスクロールバーが出るように

スマホなど狭い画面で見た際に、コードブロックの部分で内容がはみ出してスタイルが崩れてしまう。

![image](https://user-images.githubusercontent.com/67552983/148148672-be9bbc12-796e-4401-821b-e8d57a8b0df4.png)

ので、スクロールバーを出すようにする。

![image](https://user-images.githubusercontent.com/67552983/148148733-f9606e42-ab94-4312-9fe5-8f061a9480f9.png)

## 同様に、ul タグの表示あふれにも対応 

ul タグでも同様にして

![image](https://user-images.githubusercontent.com/67552983/148150005-083a84c6-0be5-4457-a9d3-efd0f6a50536.png)

スクロールバーを出すように

![image](https://user-images.githubusercontent.com/67552983/148150056-be886ea9-e06f-4317-8e58-df1bb31e81e6.png)
