### PR TITLE
HTML-escape wiki text in <textarea />

### DIFF
--- a/views/form.haml
+++ b/views/form.haml
@@ -1,5 +1,5 @@
 %form{ name: 'edit', method: 'POST' }
-  %textarea{ name: 'markdown' }!~ markdown
+  %textarea{ name: 'markdown' }~ markdown
   %br
   %label<
     Commit Message:


### PR DESCRIPTION
編集画面のtextarea内のテキストがHTMLエスケープされていなくて，ウィキページのコンテントに`</textarea>`のような文字列が含まれるときに壊れる